### PR TITLE
Fix encoding and locale issues

### DIFF
--- a/chimera.ini
+++ b/chimera.ini
@@ -17,6 +17,11 @@
 ;
 ; Removing the semicolon just before setting_name (AKA "uncommenting" the line)
 ; will result in the setting being set to "value" when read.
+;
+; To use non-ASCII characters (ie: for the 'halo.path' or `halo.exec' settings),
+; this file *MUST* be saved using the system's default 8-bit encoding (commonly
+; called "ANSI"). Using a multibyte encoding like UTF-8 will *NOT WORK* and will
+; cause crashes.
 ;===============================================================================
 
 

--- a/chimera.ini
+++ b/chimera.ini
@@ -18,10 +18,7 @@
 ; Removing the semicolon just before setting_name (AKA "uncommenting" the line)
 ; will result in the setting being set to "value" when read.
 ;
-; To use non-ASCII characters (ie: for the 'halo.path' or `halo.exec' settings),
-; this file *MUST* be saved using the system's default 8-bit encoding (commonly
-; called "ANSI"). Using a multibyte encoding like UTF-8 will *NOT WORK* and will
-; cause crashes.
+; This file *MUST* be encoded using UTF-8. Other encodings will not work.
 ;===============================================================================
 
 

--- a/src/chimera/chimera.cpp
+++ b/src/chimera/chimera.cpp
@@ -86,6 +86,9 @@ namespace Chimera {
     Chimera::Chimera() : p_signatures(find_all_signatures()) {
         chimera = this;
 
+        // Set the locale to match the system
+        std::setlocale(LC_ALL, "");
+
         // If we *can* load Chimera, then do it
         if(find_signatures()) {
             const char *build_string = *reinterpret_cast<const char **>(this->get_signature("build_string_sig").data() + 1);


### PR DESCRIPTION
When running Chimera `1ef91c18` with a non-ASCII path (set via the `-path` arg, the `path=...` setting in `chimera.ini`, or just the default path with your Windows username in it), Chimera would crash, sometimes creating 2 new folders with mangled names (one with just the `chimera/lua` folder, other other with the rest of the files). An example of a problematic path is "ÁÉÚÝÍÓŠ".

Note that ANSI is used as a shorthand by programs for "the system's preferred 8-bit encoding". In my case that's `CP-1252` (`en-US` locale).

When running with `-path ÁÉÚÝÍÓŠ` or using a ANSI-encoded `chimera.ini` (halo crashed):
![prev_ansi](https://user-images.githubusercontent.com/466941/106094946-e7b19000-6100-11eb-8d9d-e16c819486b8.png)

When using a UTF-8-encoded `chimera.ini` (notepad.exe and notepad++ both saved in UTF-8 by default) (halo crashed):
![prev_utf8](https://user-images.githubusercontent.com/466941/106094952-e97b5380-6100-11eb-92cd-b4c8f67edea6.png)

---------------------

Setting the locale of the program to match the system's configured locale fixes the issues with the default path and the `-path` argument. It also allows `chimera.ini` to be read properly as long as the file is encoded using ANSI.

Because ANSI isn't portable across systems and most text editors now save everything in UTF-8 by default, the ini parser was modified to parse values as UTF-8 strings and internally convert them to their ANSI equivalents. Error messages have been added for cases where the file isn't encoded properly, as well as when a properly-encoded UTF-8 character can't be converted to ANSI.

Many thanks to Adam Šliperski for discovering these issues and working with me to fix them.

---------------------

Some screenshots with the fixes applied to give an idea of the different error conditions:

non-ASCII characters encoded in ANSI:
![invalid_encoding](https://user-images.githubusercontent.com/466941/106093441-4e817a00-60fe-11eb-95e9-0acb8a57e31b.png)

Same as above but only in a comment:
![working_ansi](https://user-images.githubusercontent.com/466941/106093472-5f31f000-60fe-11eb-8ed4-a695c9e098d4.png)

A valid UTF-8 character that can't be converted to ANSI:
![invalid_character](https://user-images.githubusercontent.com/466941/106093457-56411e80-60fe-11eb-9327-15dd84bb1837.png)

Same as above, but only in a comment:
![working_utf8](https://user-images.githubusercontent.com/466941/106093468-5c36ff80-60fe-11eb-9523-0809a960e0ce.png)