### PR TITLE
Fix signature error messages not showing on startup

### DIFF
--- a/src/chimera/annoyance/exception_dialog.cpp
+++ b/src/chimera/annoyance/exception_dialog.cpp
@@ -11,7 +11,12 @@ namespace Chimera {
     void set_up_remove_exception_dialog() noexcept {
         static Hook hook;
         write_jmp_call(get_chimera().get_signature("gathering_exception_sig").data(), hook, reinterpret_cast<const void *>(+[]() {
-            show_error_box("Segmentation fault", "The game has encountered a segmentation fault.", get_chimera().get_ini()->get_value_bool("error_handling.show_segmentation_fault").value_or(false));
+            auto ini = get_chimera().get_ini();
+            show_error_box(
+                "Segmentation fault",
+                "The game has encountered a segmentation fault.",
+                ini != nullptr && ini->get_value_bool("error_handling.show_segmentation_fault").value_or(false)
+            );
             std::exit(68); // NOT nice
         }));
     }

--- a/src/chimera/chimera.cpp
+++ b/src/chimera/chimera.cpp
@@ -504,8 +504,7 @@ namespace Chimera {
                     break;
             }
         }
-        
-        show_error_box("Error", error_buffer);
+        show_error_box("Error", error_buffer, true, !is_server);
     }
 
     int halo_type() {

--- a/src/chimera/output/error_box.cpp
+++ b/src/chimera/output/error_box.cpp
@@ -6,10 +6,17 @@
 #include "error_box.hpp"
 
 namespace Chimera {
-    void show_error_box(const char *header, const char *text, const std::optional<bool> &force) noexcept {
+    void show_error_box(const char *header, const char *text, const std::optional<bool> &force, const std::optional<bool> &is_client) noexcept {
         auto &chimario = get_chimera();
         std::fprintf(stderr, "\n\nError [%s]\n\n----------------\n\n%s\n\n----------------\n\n", header, text);
-        if(chimario.feature_present("client") && force.value_or(!chimario.get_ini()->get_value_bool("error_handling.suppress_fatal_errors").value_or(false))) {
+        if (
+            is_client.value_or(chimario.feature_present("client")) &&
+            (
+                force.value_or(false) ||
+                chimario.get_ini() == nullptr ||
+                !chimario.get_ini()->get_value_bool("error_handling.suppress_fatal_errors").value_or(false)
+            )
+        ) {
             MessageBox(nullptr, text, header, MB_OK | MB_ICONERROR);
         }
     }

--- a/src/chimera/output/error_box.hpp
+++ b/src/chimera/output/error_box.hpp
@@ -8,11 +8,12 @@
 namespace Chimera {
     /**
      * Show an error box
-     * @param header header to show
-     * @param text   text to show
-     * @param force  force showing a message box regardless of if it is there
+     * @param header    header to show
+     * @param text      text to show
+     * @param force     force showing a message box regardless of the suppress_fatal_errors option
+     * @param is_client specify if Chimera is running as a client (default is to check for client signatures)
      */
-    void show_error_box(const char *header, const char *text, const std::optional<bool> &force = std::nullopt) noexcept;
+    void show_error_box(const char *header, const char *text, const std::optional<bool> &force = std::nullopt, const std::optional<bool> &is_client = std::nullopt) noexcept;
 }
 
 #endif


### PR DESCRIPTION
The `show_error_box` function only shows a message box if it detects Chimera is running as a client. This detection is done by checking for all the client signatures.

In order to show an error message when not all client signatures were found, an optional `is_client` paramater was added to override the signature-based check (which would always return false in this case).

A bug was also fixed where if the `show_error_box` function was called before the `chimera.ini` file was read, Chimera would segfault.