### PR TITLE
Invisible chat fix

### DIFF
--- a/src/chimera/chimera.cpp
+++ b/src/chimera/chimera.cpp
@@ -89,7 +89,7 @@ namespace Chimera {
         chimera = this;
 
         // Set the locale to match the system
-        std::setlocale(LC_ALL, "");
+        std::setlocale(LC_CTYPE, "");
 
         // If we *can* load Chimera, then do it
         if(find_signatures()) {


### PR DESCRIPTION
The bug happens on some system locales, I replicated it by setting my system on _es_AR_. 

The solution I found is really simple, instead of applying the system locale to the whole C locale, I only apply it to the _CTYPE_ category.


