### PR TITLE
Strip symbols from releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,12 @@ jobs:
 
           cd build
           make -j $(nproc)
+          
+      # Strip symbols from the DLL if building a tagged commit
+      - name: "Strip symbols"
+        if: "startsWith(github.ref, 'refs/tags/')"
+        run: |-
+          strip ./build/strings.dll
 
       - name: "Package"
         id: package


### PR DESCRIPTION
Removes about 2MB from the DLL