### PR TITLE
Add execute safe scripted chimera command

### DIFF
--- a/src/chimera/localization/language/0
+++ b/src/chimera/localization/language/0
@@ -11,6 +11,7 @@ chimera_error_command_error                                                     
 chimera_error_command_unavailable                                               %s: Command is unavailable on your Halo installation (missing %s)
 chimera_error_not_enough_arguments                                              %s: Not enough arguments were specified. Expected at least %zu
 chimera_error_too_many_arguments                                                %s: Too many arguments were specified. Expected at most %zu
+chimera_error_invalid_scripted_chimera_command                                  %s: Invalid scripted Chimera command
 
 chimera_error_must_be_in_a_server                                               You have to be in a server to do that.
 chimera_error_must_be_host                                                      You have to be the host to do that.

--- a/src/chimera/localization/language/1
+++ b/src/chimera/localization/language/1
@@ -11,6 +11,7 @@ chimera_error_command_error                                                     
 chimera_error_command_unavailable                                               %s: Comando no disponible en tu instalación de Halo (falta %s)
 chimera_error_not_enough_arguments                                              %s: No fueron especificados suficientes argumentos. Se esperaba por lo menos %zu
 chimera_error_too_many_arguments                                                %s: Se especificaron demasiados argumentos. Se esperaba como mucho %zu
+chimera_error_invalid_scripted_chimera_command                                  %s: Comando inválido de Chimera ejecutado por script
 
 chimera_custom_chat_to_all                                                      Todos
 chimera_custom_chat_to_team                                                     Equipo

--- a/src/chimera/lua/lua_game.cpp
+++ b/src/chimera/lua/lua_game.cpp
@@ -190,6 +190,47 @@ namespace Chimera {
         }
     }
 
+    // List of commands that can be executed
+    const char* allowed_chimera_commands[] = {
+        "chimera_show_fps",
+        "chimera_block_zoom_blur",
+        "chimera_devmode",
+        "chimera_budget",
+        "chimera_af",
+        "chimera_block_hold_f1",
+        "chimera_fov",
+        "chimera_mouse_sensitivity",
+        "chimera_block_buffering",
+    };
+
+    static int lua_execute_chimera_command(lua_State *state) noexcept {
+        int args = lua_gettop(state);
+        if(args == 2) {
+            bool found = false;
+            const char *command = luaL_checkstring(state, 1);
+            for (auto command_name : allowed_chimera_commands) {
+                // Check if command starts with the command name
+                if (std::strncmp(command, command_name, std::strlen(command_name)) == 0) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return luaL_error(state, localize("chimera_error_invalid_scripted_chimera_command"), command);
+            }
+            const bool save = lua_toboolean(state, 2);
+            const Command *found_command;
+            CommandResult result = get_chimera().execute_command(command, &found_command, save);\
+            if (result == COMMAND_RESULT_FAILED_ERROR_NOT_FOUND) {
+                return luaL_error(state, localize("chimera_error_command_not_found"), command);
+            }
+            return 0;
+        }
+        else {
+            return luaL_error(state, localize("chimera_lua_error_wrong_number_of_arguments"), "execute_chimera_command");
+        }
+    }
+
     static int lua_get_dynamic_player(lua_State *state) noexcept {
         int args = lua_gettop(state);
         if(args <= 1) {
@@ -580,5 +621,6 @@ namespace Chimera {
         lua_register(state, "tick_rate", lua_tick_rate);
         lua_register(state, "ticks", lua_ticks);
         lua_register(state, "create_font_override", lua_create_font_override);
+        lua_register(state, "execute_chimera_command", lua_execute_chimera_command);
     }
 }


### PR DESCRIPTION
Hi, I would like to pull request a few changes for a feature that allows you to execute a very specific list of Chimera commands from a Lua script by using a function called `execute_chimera_command`. I want to keep clear it is a very specific list of commands available to be executed here.

I know this may sound like a weird feature as even the previous API did not allow executing Chimera commands by using `execute_script`, but I've been looking for a way to simplify Chimera configuration from a UI as I'm working in another project called Insurrection that is basically a UI mod for Halo Custom Edition.

You can take a look to it in action here:
https://user-images.githubusercontent.com/40512223/216860712-63485062-306f-4687-ad0d-3123f6059f09.mp4

Mod repository here: https://github.com/Sledmine/insurrection

This UI mod uses the current Lua API to achieve several things, so one thing I was missing is the ability to interface with Chimera configuration directly without editing config files, I know there might be some "security" concerns but I think this will be really useful for new players getting in to the game :)

If there is any other better idea to handle this I will be open to hear it, Thanks!
