### PR TITLE
Clear interpolation buffers on checkpoint revert

### DIFF
--- a/src/chimera/fix/interpolate/interpolate.cpp
+++ b/src/chimera/fix/interpolate/interpolate.cpp
@@ -35,6 +35,10 @@ namespace Chimera {
 
     // Set for if interpolation is enabled
     bool interpolation_enabled = false;
+    
+    // The last value of the tick count
+    std::int32_t previous_tick= 0;
+    
 
     static void on_tick() noexcept {
         // Prevent interpolation when the game is paused
@@ -54,11 +58,22 @@ namespace Chimera {
         if(*first_person_camera_tick_rate != current_tick_rate) {
             overwrite(first_person_camera_tick_rate, current_tick_rate);
         }
+        
+        previous_tick = get_tick_count();
     }
 
     static void on_preframe() noexcept {
         if(game_paused()) {
             return;
+        }
+        
+        // Check if we've reverted and if so, clear interpolation buffers.
+        if (previous_tick > get_tick_count()) {
+            interpolate_object_clear();
+            interpolate_particle_clear();
+            interpolate_light_clear();
+            interpolate_flag_clear();
+            interpolate_camera_clear();
         }
 
         interpolation_tick_progress = get_tick_progress();


### PR DESCRIPTION
Detects whether a checkpoint revert has occurred and if so, clears the interpolation buffers. This prevents objects stored in the buffer prior to reverting being written to the object table after reverting in some rare instances (see example: https://youtu.be/7CX7Q6xsMKM)

Another example::
https://user-images.githubusercontent.com/95023823/235113164-5cf0933b-a397-4d7c-9b2c-737d9a4cc89a.mp4

